### PR TITLE
Update QUIC_CREDENTIAL_CONFIG.md

### DIFF
--- a/docs/api/QUIC_CREDENTIAL_CONFIG.md
+++ b/docs/api/QUIC_CREDENTIAL_CONFIG.md
@@ -159,7 +159,7 @@ Obtain the peer certificate using a faster in-process API call. Only available o
 
 `QUIC_CREDENTIAL_FLAG_SET_CA_CERTIFICATE_FILE`
 
-Enable CA certificate file provided in the `CaCertificateFile` member.
+Enable CA certificate file provided in the `CaCertificateFile` member. `QUIC_CREDENTIAL_FLAG_USE_TLS_BUILTIN_CERTIFICATE_VALIDATION` must be set.
 
 #### `CertificateHash`
 


### PR DESCRIPTION
Updated the doc to let the user know `QUIC_CREDENTIAL_FLAG_USE_TLS_BUILTIN_CERTIFICATE_VALIDATION` must be used if they want to add a custom CA.

## Description

This was difficult to find out manually and it does not appear to be documented elsewhere.

## Testing

N/A

## Documentation

N/A
